### PR TITLE
feat: Disable TOC On Demand 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Action to generate [Architecture Decision Records](https://adr.github.io/) Table
 
 This action also does some basic linting to:
 - Ensure no duplicate numbering of ADRs
-- ADR numbers in the filename (`0005-file.md`) matches the title (`# 5. Title`)
+- ADR numbers in the filename (`0005-file.md`) match the title (`# 5. Title`)
 - Add ADRs have titles (`# Number. Title`) as the first line
 
 ## Usage
@@ -18,6 +18,7 @@ This action also does some basic linting to:
     adr-tool-repo: 'https://github.com/npryce/adr-tools.git' # Optional. ADR Tool Repo location 
     adr-tool-version: '3.0.0' # Optional. Version of the Tools to use.
     github-token: '' # Optional. Token with which to commit
+    generate-toc: true # Optional: Specify if we should generate TOC. Defaults to true.
     generate-toc-branches: "['main', 'master']" # Optional: JSON Array of Branch names as a string. specify which branches we should generate TOC on. Defaults to main/master. 
 ```
 
@@ -27,7 +28,7 @@ This action also does some basic linting to:
 name: ADR
 
 on:
-  push: {} # Run on everything, restrict TOC generateion with 'generate-toc-branches'
+  push: {} # Run on everything, restrict TOC generation with 'generate-toc-branches'
 
 jobs:
   generate_adr_toc:

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,10 @@ name: 'Lint ADRs and Generate ADR TOC'
 description: 'Lints ADRs on branches and generates the Table of Contents for ADRs on specified'
 
 inputs:
+  generate-toc:
+    description: 'Should generate TOC'
+    required: false
+    default: true
   generate-toc-branches:
     description: 'Branches on which we will generate TOC'
     required: false
@@ -114,6 +118,7 @@ runs:
         print("::endgroup::")
     
     - name: Clone ADR Tools
+      if: ${{ inputs.generate-toc }}
       shell: bash
       run: |
         if [ "${{ contains(fromJSON(inputs.generate-toc-branches), steps.branch.outputs.BRANCH_NAME) }}" != "true" ]; then
@@ -127,6 +132,7 @@ runs:
         echo "::endgroup::"
 
     - name: Install Graphviz
+      if: ${{ inputs.generate-toc }}
       shell: bash
       run: |
         if [ "${{ contains(fromJSON(inputs.generate-toc-branches), steps.branch.outputs.BRANCH_NAME) }}" != "true" ]; then
@@ -142,6 +148,7 @@ runs:
         echo "::endgroup::"      
 
     - name: Run ADR Tools
+      if: ${{ inputs.generate-toc }}
       shell: bash
       run: |
         if [ "${{ contains(fromJSON(inputs.generate-toc-branches), steps.branch.outputs.BRANCH_NAME) }}" != "true" ]; then
@@ -175,6 +182,7 @@ and serves as more of a good starting point for the types of things you may want
         echo "::endgroup::"
 
     - name: Commit ADR TOC
+      if: ${{ inputs.generate-toc }}
       shell: bash
       run: |
         if [ "${{ contains(fromJSON(inputs.generate-toc-branches), steps.branch.outputs.BRANCH_NAME) }}" != "true" ]; then


### PR DESCRIPTION
I'm using this action for its duplication detection and title mismatch capabilities, and I don't want to commit the TOC.
As a bypass for this, I've used `generate-toc-branches: "['never-generate-toc']"` but it is not clean.

In this PR, I've added an option to disable toc on demand.